### PR TITLE
Implement Installments Service as a Payment Method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Payfort/Fort/Controller/Payment/Response.php
+++ b/Payfort/Fort/Controller/Payment/Response.php
@@ -15,6 +15,10 @@ class Response extends \Payfort\Fort\Controller\Checkout
         if($paymentMethod == $helper::PAYFORT_FORT_PAYMENT_METHOD_CC) {
             $integrationType = $helper->getConfig('payment/payfort_fort_cc/integration_type');
         }
+
+        if($paymentMethod == $helper::PAYFORT_FORT_PAYMENT_METHOD_INSTALLMENTS) {
+            $integrationType = $helper->getConfig('payment/payfort_fort_installments/integration_type');
+        }
         $success = $helper->handleFortResponse($responseParams, 'offline', $integrationType);
         if ($success) {
             $returnUrl = $helper->getUrl('checkout/onepage/success');

--- a/Payfort/Fort/Helper/Data.php
+++ b/Payfort/Fort/Helper/Data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2015 Magento. All rights reserved.
+ * Copyright ÂŠ 2015 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Payfort\Fort\Helper;
@@ -57,6 +57,7 @@ class Data extends \Magento\Payment\Helper\Data
     const PAYFORT_FORT_INTEGRATION_TYPE_MERCAHNT_PAGE = 'merchantPage';
     const PAYFORT_FORT_INTEGRATION_TYPE_MERCAHNT_PAGE2 = 'merchantPage2';
     const PAYFORT_FORT_PAYMENT_METHOD_CC = 'payfort_fort_cc';
+    const PAYFORT_FORT_PAYMENT_METHOD_INSTALLMENTS = 'payfort_fort_installments';
     const PAYFORT_FORT_PAYMENT_METHOD_NAPS = 'payfort_fort_naps';
     const PAYFORT_FORT_PAYMENT_METHOD_SADAD = 'payfort_fort_sadad';
     public function __construct(
@@ -135,6 +136,15 @@ class Data extends \Magento\Payment\Helper\Data
             $gatewayParams['service_command'] = 'TOKENIZATION';
             $gatewayParams['return_url']      = $this->getReturnUrl('payfortfort/payment/merchantPageResponse');
         }
+
+        // Installments Service
+        if($paymentMethod == self::PAYFORT_FORT_PAYMENT_METHOD_INSTALLMENTS) {
+            $gatewayParams['installments'] = 'STANDALONE';
+            // Command should always be purchase for installments (Payfort API Requirment)
+            // no matter what is the value in config
+            $gatewayParams['command'] = \Payfort\Fort\Model\Config\Source\Commandoptions::PURCHASE;
+        }
+
         $signature                  = $this->calculateSignature($gatewayParams, 'request');
         $gatewayParams['signature'] = $signature;
 
@@ -243,7 +253,7 @@ class Data extends \Magento\Payment\Helper\Data
         curl_setopt($ch, CURLOPT_ENCODING, "compress, gzip");
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1); // allow redirects		
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1); // allow redirects     
         //curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); // return into a variable
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0); // The number of seconds to wait while trying to connect
         //curl_setopt($ch, CURLOPT_TIMEOUT, Yii::app()->params['apiCallTimeout']); // timeout in seconds

--- a/Payfort/Fort/Model/Method/Installments.php
+++ b/Payfort/Fort/Model/Method/Installments.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Payment Command Types Source Model
+ *
+ * @category    Payfort
+ * @package     Payfort_Fort
+ * @author      Jonathan Hindi (j@jonathanhindi.me)
+ * @copyright   Payfort (http://www.payfort.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Payfort\Fort\Model\Method;
+
+class Installments extends \Payfort\Fort\Model\Payment
+{
+    const CODE = 'payfort_fort_installments';
+
+    protected $_code = self::CODE;
+    protected $_helper;
+    
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory,
+        \Magento\Framework\Api\AttributeValueFactory $customAttributeFactory,
+        \Payfort\Fort\Helper\Data $paymentData,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Payment\Model\Method\Logger $logger,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        parent::__construct(
+            $context,
+            $registry,
+            $extensionFactory,
+            $customAttributeFactory,
+            $paymentData,
+            $scopeConfig,
+            $logger,
+            $resource,
+            $resourceCollection,
+            $data
+        );
+        
+        $this->_code = self::CODE;
+        $this->_helper = $paymentData;
+    }
+    
+    /**
+     * Get instructions text from config
+     *
+     * @return string
+     */
+    public function getInstructions()
+    {
+        return parent::getInstructions();
+    }
+
+    /**
+     * Determine method availability based on quote amount and config data
+     *
+     * @param \Magento\Quote\Api\Data\CartInterface|null $quote
+     * @return bool
+     */
+    public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = null) 
+    {   
+        return parent::isAvailable($quote);
+    }
+}

--- a/Payfort/Fort/Model/PaymentConfigProvider.php
+++ b/Payfort/Fort/Model/PaymentConfigProvider.php
@@ -16,7 +16,8 @@ class PaymentConfigProvider implements ConfigProviderInterface
     protected $methodCodes = [
         \Payfort\Fort\Model\Method\Cc::CODE,
         \Payfort\Fort\Model\Method\Sadad::CODE,
-        \Payfort\Fort\Model\Method\Naps::CODE
+        \Payfort\Fort\Model\Method\Naps::CODE,
+        \Payfort\Fort\Model\Method\Installments::CODE
     ];
 
     /**

--- a/Payfort/Fort/Observer/AdminSystemConfigChangedPaymentObserver.php
+++ b/Payfort/Fort/Observer/AdminSystemConfigChangedPaymentObserver.php
@@ -66,6 +66,7 @@ class AdminSystemConfigChangedPaymentObserver implements ObserverInterface
     
     protected function savaCommonConfig($configKey, $configValue, $scope, $scopeId) {
         $this->_resourceConfig->saveConfig('payment/payfort_fort_cc/'.$configKey, $configValue, $scope, $scopeId);
+        $this->_resourceConfig->saveConfig('payment/payfort_fort_installments/'.$configKey, $configValue, $scope, $scopeId);
         $this->_resourceConfig->saveConfig('payment/payfort_fort_naps/'.$configKey, $configValue, $scope, $scopeId);
         $this->_resourceConfig->saveConfig('payment/payfort_fort_sadad/'.$configKey, $configValue, $scope, $scopeId);
     }

--- a/Payfort/Fort/etc/adminhtml/system.xml
+++ b/Payfort/Fort/etc/adminhtml/system.xml
@@ -143,6 +143,20 @@
                         <label>Instructions</label>
                     </field>-->
                 </group>
+                <group id="payfort_fort_installments" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>PayFort Installment Service</label>
+                    <comment>Installments Services by Payfort - Only works with Merchant Page 1 Integration Type</comment>
+                    <field id="active" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <label>Enable</label>
+                        <comment>Enable or Disable Installments Services by Payfort - Should be enabled in your payfort account first.</comment>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <config_path>payment/payfort_fort_installments/active</config_path>
+                    </field>
+                    <field id="title" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Title</label>
+                        <config_path>payment/payfort_fort_installments/title</config_path>
+                    </field>
+                </group>
                 <group id="payfort_fort_sadad" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>PayFort Sadad Payment Method</label>
                     <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/Payfort/Fort/etc/config.xml
+++ b/Payfort/Fort/etc/config.xml
@@ -37,6 +37,15 @@
                 <group>payfort_fort</group>
                 <!--<instructions>You will be redirected to the Payfort website when you place an order.</instructions>-->
             </payfort_fort_cc>
+            <payfort_fort_installments>
+                <model>Payfort\Fort\Model\Method\Installments</model>
+                <active>0</active>
+                <title>Installments with Credit / Debit Cards</title>
+                <integration_type>redirection</integration_type>
+                <order_status>payfort_fort_new</order_status>
+                <group>payfort_fort</group>
+                <!--<instructions>You will be redirected to the Payfort website when you place an order.</instructions>-->
+            </payfort_fort_installments>
             <payfort_fort_sadad>
                 <model>Payfort\Fort\Model\Method\Sadad</model>
                 <active>0</active>

--- a/Payfort/Fort/etc/payment.xml
+++ b/Payfort/Fort/etc/payment.xml
@@ -20,6 +20,9 @@
         <method name="payfort_fort_cc">
             <allow_multiple_address>0</allow_multiple_address>
         </method>
+        <method name="payfort_fort_installments">
+            <allow_multiple_address>0</allow_multiple_address>
+        </method>
         <method name="payfort_fort_sadad">
             <allow_multiple_address>0</allow_multiple_address>
         </method>

--- a/Payfort/Fort/view/frontend/layout/checkout_index_index.xml
+++ b/Payfort/Fort/view/frontend/layout/checkout_index_index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright © 2015 Magento. All rights reserved.
+ * Copyright ÂŠ 2015 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 -->
@@ -27,6 +27,9 @@
                                                                     <item name="component" xsi:type="string">Payfort_Fort/js/view/payment/payfort-payments</item>
                                                                     <item name="methods" xsi:type="array">
                                                                         <item name="payfort_fort_cc" xsi:type="array">
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                        </item>
+                                                                        <item name="payfort_fort_installments" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
                                                                         </item>
                                                                         <item name="payfort_fort_sadad" xsi:type="array">

--- a/Payfort/Fort/view/frontend/layout/onestepcheckout_index_index.xml
+++ b/Payfort/Fort/view/frontend/layout/onestepcheckout_index_index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright © 2015 Magento. All rights reserved.
+ * Copyright ÂŠ 2015 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 -->
@@ -28,6 +28,9 @@
                                                                     <item name="component" xsi:type="string">Payfort_Fort/js/view/payment/payfort-payments</item>
                                                                     <item name="methods" xsi:type="array">
                                                                         <item name="payfort_fort_cc" xsi:type="array">
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                        </item>
+                                                                        <item name="payfort_fort_installments" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
                                                                         </item>
                                                                         <item name="payfort_fort_sadad" xsi:type="array">

--- a/Payfort/Fort/view/frontend/web/js/view/payment/method-renderer/payfort_fort_installments-method.js
+++ b/Payfort/Fort/view/frontend/web/js/view/payment/method-renderer/payfort_fort_installments-method.js
@@ -1,0 +1,57 @@
+/**
+ * Payfot_Fort Magento JS component
+ *
+ * @category    Payfort
+ * @package     Payfot_Fort
+ * @author      Jonathan Hindi
+ * @copyright   Payfort (http://www.payfort.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+/*browser:true*/
+/*global define*/
+define(
+    [
+        'ko',
+        'jquery',
+        'Magento_Checkout/js/view/payment/default',
+        'Magento_Checkout/js/model/quote',
+        'Magento_Checkout/js/model/full-screen-loader',
+        'Magento_Checkout/js/action/set-payment-information',
+        'Magento_Checkout/js/action/place-order',
+    ],
+    function (ko, $, Component, quote, fullScreenLoader, setPaymentInformationAction, placeOrder) {
+        'use strict';
+        return Component.extend({
+            defaults: {
+                template: 'Payfort_Fort/payment/payfort-form'
+            },
+            getCode: function() {
+                return 'payfort_fort_installments';
+            },
+            isActive: function() {
+                return true;
+            },
+            context: function() {
+                return this;
+            },
+            getInstructions: function() {
+                return window.checkoutConfig.payment.payfortFort.payfort_fort_installments.instructions;
+            },
+            // Overwrite properties / functions
+            redirectAfterPlaceOrder: false,
+            
+            afterPlaceOrder : function() {
+                $.mage.redirect(window.checkoutConfig.payment.payfortFort.payfort_fort_cc.redirectUrl);
+            },
+            isChecked: ko.computed(function () {
+                var checked = quote.paymentMethod() ? quote.paymentMethod().method : null;
+                if(window.checkoutConfig.payment.payfortFort.configParams.gatewayCurrency == 'front') {
+                    if(checked) {
+                        $('.totals.charge').hide();
+                    }
+                }
+                return checked;
+            }),
+        });
+    }
+);

--- a/Payfort/Fort/view/frontend/web/js/view/payment/payfort-payments.js
+++ b/Payfort/Fort/view/frontend/web/js/view/payment/payfort-payments.js
@@ -31,6 +31,10 @@ define(
                 component: window.checkoutConfig.payment.payfortFort.payfort_fort_cc.integrationType == 'merchantPage2' ? 'Payfort_Fort/js/view/payment/method-renderer/payfort_fort_cc_merchant_page2-method' : 'Payfort_Fort/js/view/payment/method-renderer/payfort_fort_cc-method'
             },
             {
+                type: 'payfort_fort_installments',
+                component: 'Payfort_Fort/js/view/payment/method-renderer/payfort_fort_installments-method'
+            },
+            {
                 type: 'payfort_fort_sadad',
                 component: 'Payfort_Fort/js/view/payment/method-renderer/payfort_fort_sadad-method'
             },


### PR DESCRIPTION
I've implemented the [Installments Service](https://docs.payfort.com/#installments-service) by Payfort as an extra Payment method beside (Debit/Credit, NAPS & Sadad). 

Things to note, I have only implemented the method using the [Redirection Integration Type](https://docs.payfort.com/#redirection-installments-service-request) for now as this was the scope of the project I'm working on.

Also, I'm overriding/hardcoding the `command` parameter only for the Installments Method as it's required by the API to use `Purchase` not `Authorization`. 

For the service to work probably, the Installments Service should be enabled from Payfort side first, we have also faced some issues specifically for our account that were fixed after contacting Payfort helpful support: 
* (00046 Channel not configured for selected payment option)
* (00095 Inactive Issuer)

Please let me know if you need me to match any code style guides or something so that the pull request get accepted. 

Cheers-- J
