### PR TITLE
Revert items to inventory manually in 2.2.4+

### DIFF
--- a/Payfort/Fort/composer.json
+++ b/Payfort/Fort/composer.json
@@ -2,7 +2,7 @@
   "name": "PayFort Fort Payment Module",
   "description": "Use PayFort Fort module to have access to Fort payment methods.",
   "type": "magento2-module",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "license": [
     "MIT"
   ],

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ PAYFORT is here to help you accept online payments, reduce fraud, and maximize y
 
 ## Changelog
 
+`v1.4.1`
+- Return items to stock if order fails in Magento versions 2.2.4+
+
 `v1.4.0`
 - Support Magento 2.3
 


### PR DESCRIPTION
Fix issue where a failed order in Magento versions 2.2.4 and newer would not return the items to the stock. 