### PR TITLE
Update Subscriptiondata.php

### DIFF
--- a/magento2-aps/Amazonpaymentservices/Fort/Plugin/Checkout/Ordersummary/Subscriptiondata.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Plugin/Checkout/Ordersummary/Subscriptiondata.php
@@ -31,6 +31,11 @@ class Subscriptiondata
         foreach ($items as $index => $item) {
 
             $quoteItem = $this->checkoutSession->getQuote()->getItemById($item['item_id']);
+            
+            if (!$quoteItem) {
+                continue;    
+            }
+            
             $productEntityId = $quoteItem->getProduct()->getData('entity_id');
 
             $resource = ObjectManager::getInstance()->get('Magento\Framework\App\ResourceConnection');


### PR DESCRIPTION
If ```$this->checkoutSession->getQuote()->getItemById($item['item_id']);``` returns false, the we get the below error causing the checkout flow to break.

Call to a member function getProduct() on bool in /var/www/html/mumzworldtest/app/code/Amazonpaymentservices/Fort/Plugin/Checkout/Ordersummary/Subscriptiondata.php:34