### PR TITLE
Removed the layout declaration from the checkout_index_index.xml

### DIFF
--- a/magento2-aps/Amazonpaymentservices/Fort/view/frontend/layout/checkout_index_index.xml
+++ b/magento2-aps/Amazonpaymentservices/Fort/view/frontend/layout/checkout_index_index.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="Amazonpaymentservices_Fort::css/checkout-page.css"/>
         <css src="Amazonpaymentservices_Fort::css/payfort-valu.css" />


### PR DESCRIPTION
Removed the layout declaration from the checkout_index_index.xml as this is getting overwritten by theme adjustments. This is not really required here as Magento already declared this and it's theme's job change this if it's required.