### PR TITLE
fix: jaywan bin cvv validation

### DIFF
--- a/magento2-aps/Amazonpaymentservices/Fort/Model/Method/Cc.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Model/Method/Cc.php
@@ -191,7 +191,7 @@ class Cc extends \Amazonpaymentservices\Fort\Model\Payment
     {
         $years = [];
         $first = (int)$this->_date->date('Y');
-        for ($index = 0; $index <= \Magento\Payment\Model\Config::YEARS_RANGE; $index++) {
+        for ($index = 0; $index <= 20; $index++) {
             $year = $first + $index;
             $years[$year] = $year;
         }

--- a/magento2-aps/Amazonpaymentservices/Fort/view/frontend/requirejs-config.js
+++ b/magento2-aps/Amazonpaymentservices/Fort/view/frontend/requirejs-config.js
@@ -23,6 +23,9 @@ var config = {
         mixins: {
             'Magento_Checkout/js/view/minicart': {
                 'Amazonpaymentservices_Fort/js/view/minicart-apple': true
+            },
+            'mage/validation': {
+                'Amazonpaymentservices_Fort/js/validation-mixin': true
             }
         }
     }

--- a/magento2-aps/Amazonpaymentservices/Fort/view/frontend/web/js/validation-mixin.js
+++ b/magento2-aps/Amazonpaymentservices/Fort/view/frontend/web/js/validation-mixin.js
@@ -1,0 +1,31 @@
+define([
+    'jquery'
+], function ($) {
+    'use strict';
+
+    return function (originalValidator) {
+        $.validator.addMethod(
+            'validate-cc-cvn',
+            function (value, element, params) {
+                var ccType,
+                    customTypes = {
+                        'JW': [new RegExp('^(669010|669009|978450|47878000|622454|650053|650483)[0-9]*$'), new RegExp('^[0-9]{3}$'), true],
+                        'MZ': [new RegExp('^[0-9]{16,19}$'), new RegExp('^[0-9]{3}$'), true]
+                    };
+
+                if (value && params) {
+                    ccType = $(params).val();
+
+                    if (customTypes[ccType] && customTypes[ccType][1]) {
+                        return customTypes[ccType][1].test(value);
+                    }
+                }
+
+                return originalValidator.call(this, value, element, params);
+            },
+            $.mage.__('Please enter a valid credit card verification number.')
+        );
+
+        return originalValidator;
+    };
+});


### PR DESCRIPTION
 Problem: When entering a Jaywan card number, the card was correctly detected and the Jaywan logo appeared, but the CVV field threw "Please enter a valid credit card verification number" even with a valid 3-digit CVV.
  
  Root Cause: Magento's core validate-cc-cvn validator in lib/web/mage/validation.js uses a creditCartTypes map that doesn't include JW (Jaywan) or MZ (Meeza). When the card type is detected as JW, the validator can't find it in the map and
  returns invalid.
  
  Fix: Added a mixin (validation-mixin.js) that extends Magento's validate-cc-cvn rule to recognize JW and MZ card types with 3-digit CVV validation. Registered the mixin in requirejs-config.js.
  