### PR TITLE
Fix: Adding order status validation

### DIFF
--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/AppleCancelResponse.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/AppleCancelResponse.php
@@ -46,12 +46,15 @@ class AppleCancelResponse extends \Amazonpaymentservices\Fort\Controller\Checkou
     {
         $order = $this->_checkoutSession->getLastRealOrder();
         $helper = $this->getHelper();
-        $integrationType = $helper->getConfig('payment/aps_installment/integration_type');
-        
+        $returnUrl = $helper->getUrl('checkout/cart');
+
+        if (!$order->getId() || $order->getQuoteId() != $this->_checkoutSession->getQuoteId()) {
+            $this->orderRedirect($returnUrl);
+            return;
+        }
+
         $this->messageManager
         ->addError(__('You have cancelled the payment, please try again.'));
-        
-        $returnUrl = $helper->getUrl('checkout/cart');
 
         $orderAfterPayment = $helper->getMainConfigData('orderafterpayment');
 

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/AppleFailedResponse.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/AppleFailedResponse.php
@@ -46,6 +46,13 @@ class AppleFailedResponse extends \Amazonpaymentservices\Fort\Controller\Checkou
     {
         $order = $this->_checkoutSession->getLastRealOrder();
         $helper = $this->getHelper();
+        $returnUrl = $helper->getUrl('checkout/cart');
+
+        if (!$order->getId() || $order->getQuoteId() != $this->_checkoutSession->getQuoteId()) {
+            $this->orderRedirect($returnUrl);
+            return;
+        }
+
         $integrationType = $helper->getConfig('payment/aps_installment/integration_type');
         $r = $helper->cancelOrder($order, 'You have cancelled the payment, please try again.');
         
@@ -53,8 +60,6 @@ class AppleFailedResponse extends \Amazonpaymentservices\Fort\Controller\Checkou
             $helper->restoreQuote();
             $this->messageManager->addError('You have cancelled the payment, please try again.');
         }
-        
-        $returnUrl = $helper->getUrl('checkout/cart');
 
         $orderAfterPayment = $helper->getMainConfigData('orderafterpayment');
 

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/InstallmentResponseOnline.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/InstallmentResponseOnline.php
@@ -56,10 +56,12 @@ class InstallmentResponseOnline extends \Amazonpaymentservices\Fort\Controller\C
             }
         }
 
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
         
         $this->orderRedirect($returnUrl);
     }

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/InstallmentStandardPageResponse.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/InstallmentStandardPageResponse.php
@@ -84,10 +84,12 @@ class InstallmentstandardPageResponse extends \Amazonpaymentservices\Fort\Contro
             }
         }
         
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
 
         if ($integrationType == \Amazonpaymentservices\Fort\Model\Config\Source\Integrationtypeoptions::STANDARD) {
             $redirectURL =  '<script>window.top.location.href = "'.$returnUrl.'"</script>';

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/MerchantPageResponse.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/MerchantPageResponse.php
@@ -93,10 +93,12 @@ class MerchantPageResponse extends \Amazonpaymentservices\Fort\Controller\Checko
             }
         }
         
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
 
         if ($integrationType == \Amazonpaymentservices\Fort\Model\Config\Source\Integrationtypeoptions::STANDARD) {
             $redirectURL =  '<script>window.top.location.href = "'.$returnUrl.'"</script>';

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/MerchantPageVaultResponse.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/MerchantPageVaultResponse.php
@@ -92,10 +92,12 @@ class MerchantPageVaultResponse extends \Amazonpaymentservices\Fort\Controller\C
                 }
             }
         }
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
 
         $this->orderRedirect($returnUrl);
 

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/OrderCancel.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/OrderCancel.php
@@ -25,14 +25,19 @@ class OrderCancel extends \Amazonpaymentservices\Fort\Controller\Checkout implem
     public function execute()
     {
         $helper = $this->getHelper();
-        
         $order = $this->_checkoutSession->getLastRealOrder();
+        $returnUrl = $helper->getUrl('checkout/cart');
+
+        if (!$order->getId() || $order->getQuoteId() != $this->_checkoutSession->getQuoteId()) {
+            $this->orderRedirect($returnUrl);
+            return;
+        }
+
         if ($order->getState() != $order::STATE_PROCESSING) {
             $success = $helper->orderFailed($order, 'Payment cancelled by user', '');
             $helper->restoreQuote($order);
             $this->messageManager->addError(__('Payment cancelled by user'));
         }
-        $returnUrl = $helper->getUrl('checkout/cart');
 
         $orderAfterPayment = $helper->getMainConfigData('orderafterpayment');
 
@@ -40,11 +45,13 @@ class OrderCancel extends \Amazonpaymentservices\Fort\Controller\Checkout implem
         if ($orderAfterPayment === OrderOptions::DELETE_ORDER && !$helper->isOrderResponseOnHold($responseParams['response_code'] ?? '')) {
             $helper->deleteOrder($order);
         }
-        
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+
+        if ($order->getQuoteId() && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
         
         $this->orderRedirect($returnUrl);
     }

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/Response.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/Response.php
@@ -82,10 +82,12 @@ class Response extends \Amazonpaymentservices\Fort\Controller\Checkout implement
             }
         }
 
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
 
         $this->orderRedirect($returnUrl);
     }

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/ResponseOnline.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/ResponseOnline.php
@@ -64,10 +64,12 @@ class ResponseOnline extends \Amazonpaymentservices\Fort\Controller\Checkout imp
             }
         }
 
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
 
         $result = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $result->setUrl($returnUrl);

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/StcResponse.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/StcResponse.php
@@ -62,10 +62,12 @@ class StcResponse extends \Amazonpaymentservices\Fort\Controller\Checkout implem
             }
         }
 
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
 
         $this->orderRedirect($returnUrl);
     }

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/StcResponseOnline.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/StcResponseOnline.php
@@ -64,10 +64,12 @@ class StcResponseOnline extends \Amazonpaymentservices\Fort\Controller\Checkout 
             }
         }
 
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
         
         $this->orderRedirect($returnUrl);
     }

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/TabbyResponseOnline.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/TabbyResponseOnline.php
@@ -61,10 +61,12 @@ class TabbyResponseOnline extends \Amazonpaymentservices\Fort\Controller\Checkou
             }
         }
 
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
 
         $this->orderRedirect($returnUrl);
     }

--- a/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/VisaCheckoutResponse.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Controller/Payment/VisaCheckoutResponse.php
@@ -94,10 +94,12 @@ class VisaCheckoutResponse extends \Amazonpaymentservices\Fort\Controller\Checko
                 }
             }
         }
-        $this->_checkoutSession->setLastOrderId($order->getId());
-        $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
-        $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        if ($success && $order->getQuoteId() == $this->_checkoutSession->getQuoteId()) {
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
+        }
         
         $helper->log('Checkout Session Data3:'.$this->_checkoutSession->getLastSuccessQuoteId());
         $helper->log('Checkout Session order Id Data3:'.$this->_checkoutSession->getLastRealOrderId());

--- a/magento2-aps/Amazonpaymentservices/Fort/Helper/Data.php
+++ b/magento2-aps/Amazonpaymentservices/Fort/Helper/Data.php
@@ -1887,10 +1887,12 @@ class Data extends \Magento\Payment\Helper\Data
         }
         if ($order->getId() && $order->getState() != Order::STATE_CANCELED) {
             $order->cancel();
-            $order->addStatusToHistory($order::STATE_CANCELED, $comment, false);
+            if ($order->getState() == Order::STATE_CANCELED) {
+                $order->addStatusToHistory($order::STATE_CANCELED, $comment, false);
+            } else {
+                $order->addCommentToStatusHistory($comment, false, false);
+            }
             $order->save();
-
-//            $order->registerCancellation($comment)->save();
             return true;
         }
         return false;
@@ -1909,14 +1911,12 @@ class Data extends \Magento\Payment\Helper\Data
         }
         if ($order->getState() != Order::STATE_CANCELED) {
             $order->cancel();
-            $order->addStatusToHistory($order::STATE_CANCELED, $comment, false);
+            if ($order->getState() == Order::STATE_CANCELED) {
+                $order->addStatusToHistory($order::STATE_CANCELED, $comment, false);
+            } else {
+                $order->addCommentToStatusHistory($comment, false, false);
+            }
             $order->save();
-
-//            $order->registerCancellation($comment)->save();
-            /*if ($this->restoreQuote()) {
-                //Redirect to payment step
-                $gotoSection = 'paymentMethod';
-            }*/
             $gotoSection = true;
         }
         return $gotoSection;

--- a/magento2-aps/Amazonpaymentservices/Fort/composer.json
+++ b/magento2-aps/Amazonpaymentservices/Fort/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "amazonpaymentservices/module-fort",
     "description": "APS integration with payment gateway",
-    "version": "2.6.17",
+    "version": "2.6.18",
     "type": "magento2-module",
     "license": [
         "MIT"

--- a/magento2-aps/Amazonpaymentservices/Fort/etc/module.xml
+++ b/magento2-aps/Amazonpaymentservices/Fort/etc/module.xml
@@ -10,7 +10,7 @@
  **/
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Amazonpaymentservices_Fort" setup_version="2.6.17">
+    <module name="Amazonpaymentservices_Fort" setup_version="2.6.18">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />


### PR DESCRIPTION
1. Validate order existence and quote ID against current session before processing payment responses — redirect to cart if mismatched
2. Wrap checkout session updates (setLastOrderId, etc.) in success + quote ID match condition.
3. Fix order cancellation in Helper/Data.php to handle non-cancellable states gracefully (add comment instead of forcing canceled status).